### PR TITLE
Cloudfront support

### DIFF
--- a/baipw/tests/test_utils.py
+++ b/baipw/tests/test_utils.py
@@ -79,3 +79,7 @@ class TestGetClientIP(TestCase):
         self.request.META["HTTP_X_FORWARDED_FOR"] = "110.123.123.89"
         self.assertIn("REMOTE_ADDR", self.request.META)
         self.assertEqual(get_client_ip(self.request), "72.123.123.90")
+
+    def test_get_client_ip_from_cloudfront(self):
+        self.request.META["HTTP_CLOUDFRONT_VIEWER_ADDRESS"] = "72.123.123.90"
+        self.assertEqual(get_client_ip(self.request), "72.123.123.90")

--- a/baipw/utils.py
+++ b/baipw/utils.py
@@ -7,6 +7,9 @@ from .exceptions import Unauthorized
 
 
 def get_client_ip(request):
+    # IP retrieved from CloudFront
+    cloudfront_viewer_address = request.META.get("HTTP_CLOUDFRONT_VIEWER_ADDRESS")
+
     # IP retrieved from CloudFlare
     cf_connecting_ip = request.META.get("HTTP_CF_CONNECTING_IP")
 
@@ -18,7 +21,9 @@ def get_client_ip(request):
     remote_addr = request.META.get("REMOTE_ADDR")
 
     # Prioritise IPs from proxies.
-    final_ip = cf_connecting_ip or x_forwarded_for or remote_addr
+    final_ip = (
+        cloudfront_viewer_address or cf_connecting_ip or x_forwarded_for or remote_addr
+    )
 
     # If no IP address was attached to the address, return nothing.
     if final_ip is None:


### PR DESCRIPTION
Add support for CloudFront's client source IP header.

See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html#cloudfront-headers-device-type for relevant documentation

Now there are a few different header candidates, I moved them into a list and iterated instead.