### PR TITLE
Use the first value when given multiple IPs, not the last

### DIFF
--- a/baipw/tests/test_utils.py
+++ b/baipw/tests/test_utils.py
@@ -68,7 +68,7 @@ class TestGetClientIP(TestCase):
         self.assertEqual(get_client_ip(self.request), "72.123.123.89")
 
     def test_get_client_ip_from_x_forwaded_for_when_multiple_values(self):
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "72.123.123.89,5.123.2.45"
+        self.request.META["HTTP_X_FORWARDED_FOR"] = "5.123.2.45,72.123.123.89"
         self.assertIn("HTTP_X_FORWARDED_FOR", self.request.META)
         self.assertIn("REMOTE_ADDR", self.request.META)
         # Should use the last IP from the list.

--- a/baipw/utils.py
+++ b/baipw/utils.py
@@ -24,9 +24,9 @@ def get_client_ip(request):
     if final_ip is None:
         return
 
-    # If there is a list of IPs provided, use the last one (should be
-    # the most recent one). This may not work on Google Cloud.
-    return final_ip.split(",")[-1].strip()
+    # If there is a list of IPs provided, use the first one as
+    # this should be the original client's IP
+    return final_ip.split(",", 1)[0].strip()
 
 
 def authorize(request, configured_username, configured_password):


### PR DESCRIPTION
We want the clients' IP, which should always be the source of the request, not the most recent proxy.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#syntax.

This makes the assumption that "Client" should where possible denote the original source of the request, not the device directly next to Django (which is generally what `REMOTE_ADDR` is).