### PR TITLE
Use django-ipware for detecting client's IP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,13 +87,9 @@ Advanced customisation
 Getting IP
 ~~~~~~~~~~
 
-If you want to have a custom behaviour when getting IP, you can create a
-custom function that takes request as a parameter and specify path to it
-in the ``BASIC_AUTH_GET_CLIENT_IP_FUNCTION`` settings, e.g.
-
-.. code:: python
-
-   BASIC_AUTH_GET_CLIENT_IP_FUNCTION = 'utils.ip.get_client_ip'
+Under the hood, `django-ipware <https://github.com/un33k/django-ipware>`_ is used
+for detecting the client's IP address. See their documentation for customization and
+security hardening.
 
 
 ``BASIC_AUTH_WHITELISTED_HTTP_HOSTS``

--- a/baipw/middleware.py
+++ b/baipw/middleware.py
@@ -4,9 +4,11 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.utils.module_loading import import_string
 
+from ipware import get_client_ip
+
 from .exceptions import Unauthorized
 from .response import HttpUnauthorizedResponse
-from .utils import authorize, get_client_ip
+from .utils import authorize
 
 
 class BasicAuthIPWhitelistMiddleware:
@@ -61,11 +63,8 @@ class BasicAuthIPWhitelistMiddleware:
             return self.get_response_class()(request=request)
 
     def _get_client_ip(self, request):
-        function_path = getattr(settings, "BASIC_AUTH_GET_CLIENT_IP_FUNCTION", None)
-        func = get_client_ip
-        if function_path is not None:
-            func = import_string(function_path)
-        return func(request)
+        client_ip, _ = get_client_ip(request)
+        return client_ip
 
     def _get_whitelisted_networks(self):
         networks = getattr(settings, "BASIC_AUTH_WHITELISTED_IP_NETWORKS", [])

--- a/baipw/tests/test_middleware.py
+++ b/baipw/tests/test_middleware.py
@@ -186,16 +186,6 @@ class TestIpWhitelisting(TestCaseMixin, TestCase):
         # But it called the IP check.
         ip_check_m.assert_called_once_with(self.request)
 
-    @override_settings(
-        BASIC_AUTH_GET_CLIENT_IP_FUNCTION=("baipw.tests.utils.custom_get_client_ip"),
-    )
-    def test_get_custom_get_client_ip(self):
-        with mock.patch("baipw.tests.utils.custom_get_client_ip") as m:
-            with mock.patch("baipw.utils.get_client_ip") as default_m:
-                self.middleware._get_client_ip(self.request)
-        m.self_assert_called_once_with(self.request)
-        default_m.assert_not_called()
-
     def test_whitelisted_http_host_setting_when_setting_not_set(self):
         self.assertFalse(list(self.middleware._get_whitelisted_http_hosts()))
 

--- a/baipw/tests/test_utils.py
+++ b/baipw/tests/test_utils.py
@@ -3,7 +3,7 @@ import base64
 from django.test import RequestFactory, TestCase
 
 from baipw.exceptions import Unauthorized
-from baipw.utils import authorize, get_client_ip
+from baipw.utils import authorize
 
 
 class TestAuthorize(TestCase):
@@ -43,39 +43,3 @@ class TestAuthorize(TestCase):
         self.assertEqual(
             str(e.exception), "Invalid format of the authorization header."
         )
-
-
-class TestGetClientIP(TestCase):
-    def setUp(self):
-        self.request = RequestFactory().get("/")
-
-    def test_get_client_ip_from_remote_addr(self):
-        self.request.META["REMOTE_ADDR"] = "192.168.0.17"
-        self.assertNotIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        self.assertEqual(get_client_ip(self.request), "192.168.0.17")
-
-    def test_get_client_ip_if_no_remote_addr_or_x_forwaded_for(self):
-        del self.request.META["REMOTE_ADDR"]
-        self.assertNotIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertNotIn("REMOTE_ADDR", self.request.META)
-        self.assertIsNone(get_client_ip(self.request))
-
-    def test_get_client_ip_from_x_forwaded_for(self):
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "72.123.123.89"
-        self.assertIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        self.assertEqual(get_client_ip(self.request), "72.123.123.89")
-
-    def test_get_client_ip_from_x_forwaded_for_when_multiple_values(self):
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "72.123.123.89,5.123.2.45"
-        self.assertIn("HTTP_X_FORWARDED_FOR", self.request.META)
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        # Should use the last IP from the list.
-        self.assertEqual(get_client_ip(self.request), "5.123.2.45")
-
-    def test_get_client_ip_prioritises_cloudflare_ip(self):
-        self.request.META["HTTP_CF_CONNECTING_IP"] = "72.123.123.90"
-        self.request.META["HTTP_X_FORWARDED_FOR"] = "110.123.123.89"
-        self.assertIn("REMOTE_ADDR", self.request.META)
-        self.assertEqual(get_client_ip(self.request), "72.123.123.90")

--- a/baipw/tests/utils.py
+++ b/baipw/tests/utils.py
@@ -1,2 +1,0 @@
-def custom_get_client_ip():
-    pass

--- a/baipw/utils.py
+++ b/baipw/utils.py
@@ -6,29 +6,6 @@ from django.utils.crypto import constant_time_compare
 from .exceptions import Unauthorized
 
 
-def get_client_ip(request):
-    # IP retrieved from CloudFlare
-    cf_connecting_ip = request.META.get("HTTP_CF_CONNECTING_IP")
-
-    # Header usually set by proxies
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-
-    # Header set by the connecting party, usually not the actual client making
-    # the request, but a web server that the request goes through.
-    remote_addr = request.META.get("REMOTE_ADDR")
-
-    # Prioritise IPs from proxies.
-    final_ip = cf_connecting_ip or x_forwarded_for or remote_addr
-
-    # If no IP address was attached to the address, return nothing.
-    if final_ip is None:
-        return
-
-    # If there is a list of IPs provided, use the last one (should be
-    # the most recent one). This may not work on Google Cloud.
-    return final_ip.split(",")[-1].strip()
-
-
 def authorize(request, configured_username, configured_password):
     """
     Match authorization header present in the request against

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ keywords =
 packages = find:
 install_requires =
     Django>=1.8,<5
+    django-ipware>=4
 python_requires = >=3.4
 
 [options.extras_require]


### PR DESCRIPTION
This is more customizable, and has more secure default functionality.

Note this conflicts with #12 and replaces #13. This also removes the custom support for Cloudflare's header, which instead will need to be manually added to `IPWARE_META_PRECEDENCE_ORDER`.