### PR TITLE
Upgrade test suite and metadata for Django 5.0 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
-        django-version: [18, 19, 110, 111, 20, 21, 22, 30, 31, 32, 40, main]
+        django-version: [18, 19, 110, 111, 20, 21, 22, 30, 31, 32, 40, 50, main]
         experimental: [false]
 
         # Allow failures on Django main branch test.
@@ -53,6 +53,8 @@ jobs:
           - python-version: 3.5
             django-version: 40
           - python-version: 3.5
+            django-version: 50
+          - python-version: 3.5
             django-version: main
 
           # Python 3.6
@@ -64,6 +66,8 @@ jobs:
             django-version: 110
           - python-version: 3.6
             django-version: 40
+          - python-version: 3.6
+            django-version: 50
           - python-version: 3.6
             django-version: main
 
@@ -78,6 +82,8 @@ jobs:
             django-version: 111
           - python-version: 3.7
             django-version: 40
+          - python-version: 3.7
+            django-version: 50
           - python-version: 3.7
             django-version: main
 
@@ -98,6 +104,8 @@ jobs:
           - python-version: 3.8
             django-version: 21
           - python-version: 3.8
+            django-version: 50
+          - python-version: 3.8
             django-version: main
 
           # Python 3.9
@@ -115,6 +123,8 @@ jobs:
             django-version: 20
           - python-version: "3.9"
             django-version: 21
+          - python-version: "3.9"
+            django-version: 50
           - python-version: "3.9"
             django-version: main
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,10 @@ classifiers =
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
 keywords =
     django
     basic
@@ -40,7 +44,7 @@ keywords =
 [options]
 packages = find:
 install_requires =
-    Django>=1.8,<5
+    Django>=1.8,<6
 python_requires = >=3.4
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py{35,36,37,38}-dj{22}
     py{36,37,38,39}-dj{30,32,main}
     py{38,39,310}-dj{32,40,main}
+    py{310}-dj{50,main}
     flake8
     isort
 
@@ -25,6 +26,7 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4,<4.1
+    dj50: Django>=5,<5.1
     djmain: https://github.com/django/django/archive/main.tar.gz
 install_command = pip install -e . -U {opts} {packages}
 commands =


### PR DESCRIPTION
The only change really required is to upgrade the dependency definition to `<6`. I’ve also updated:

- Tox configuration. Tested locally with `tox -e py310-dj50`.
- GitHub Actions matrix configuration.
- Trove classifiers.

I also tried to run `django-upgrade` on the project. There were changes it made but none that were technically required for Django 5 support.