### PR TITLE
Prevent basic auth pages from being indexed

### DIFF
--- a/baipw/tests/test_integration.py
+++ b/baipw/tests/test_integration.py
@@ -32,7 +32,7 @@ class TestIntegration(test.TestCase):
 
     def test_basic_auth_not_configured(self):
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
     @test.override_settings(
         BASIC_AUTH_LOGIN="test",


### PR DESCRIPTION
If a page has basic auth enabled after it's already been indexed, Google won't remove it, as Google can't see the `noindex` tag since it's behind basic auth.

This PR adds a `X-Robots-Tag` header to allow search engines to remove the page even whilst basic auth is enabled.

There shouldn't be a case where search engines index a page with basic auth, but on the off chance there was, this should prevent that too.